### PR TITLE
Disable death on podium

### DIFF
--- a/Term8_GameDesign/Assets/Scenes/TitleSceneWithJoyConSupport.unity
+++ b/Term8_GameDesign/Assets/Scenes/TitleSceneWithJoyConSupport.unity
@@ -700,7 +700,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   matchMin: 0
-  matchSec: 10
+  matchSec: 30
   minCountdown: {fileID: 731482068}
   msecCountdown: {fileID: 2069130741}
   invisPlatform: {fileID: 1792674437}
@@ -4046,7 +4046,7 @@ MonoBehaviour:
     m_ActionId: d50ae7eb-9ca2-43c2-b23b-5f84ecdfb32e
     m_ActionName: CharacterActions/StartButton[/Keyboard/p]
   m_NeverAutoSwitchControlSchemes: 1
-  m_DefaultControlScheme: Gamepad
+  m_DefaultControlScheme: Keyboard&Mouse
   m_DefaultActionMap: UIActions
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
@@ -25198,7 +25198,7 @@ MonoBehaviour:
   podium: {fileID: 1105154360}
   controlsManager: {fileID: 1517808936}
   spawnPickupsScript: {fileID: 1748545542}
-  requiredPlayersToStart: 1
+  requiredPlayersToStart: 2
   readyPlayersNum: 0
   toSelectPlaySFX: {fileID: 8300000, guid: d2701761ad919584d8a04bbe6b134f28, type: 3}
   roundEndSFX: {fileID: 8300000, guid: 8ad6ea618b89ebf49ac2fdd93b8ecb97, type: 3}

--- a/Term8_GameDesign/Assets/Scripts/Characters/DrProfessor.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/DrProfessor.cs
@@ -57,14 +57,4 @@ public class DrProfessor : GenericCharacter
             Debug.Log("Potion 2!!");
         }
     }
-
-    public override void OnDeath()
-    {
-        animator.SetBool("IsJumping", false);
-        animator.SetTrigger("Death");
-        float deathAnimLength = animator.GetCurrentAnimatorStateInfo(0).length;
-        StartCoroutine(SetSpawnPosition(deathAnimLength));
-        // throw new System.NotImplementedException();
-    }
-
 }

--- a/Term8_GameDesign/Assets/Scripts/Characters/GenericCharacter.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/GenericCharacter.cs
@@ -32,6 +32,7 @@ public abstract class GenericCharacter : MonoBehaviour
     public bool isFast = false;      // used to prevent stacking of swiftness elixirs
     [SerializeField]
     private float speedBoostMultiplier = 1.75f;
+    public bool isPodiumScene = false;      // used in podium scene to disallow some actions
 
     // death respawn stuff
     public float respawnTime = 2f;
@@ -118,7 +119,7 @@ public abstract class GenericCharacter : MonoBehaviour
 
     public void SecPotInput(InputAction.CallbackContext context)
     {
-        if (timeBtwAttack <= 0 && canMove)
+        if (timeBtwAttack <= 0 && canMove && !isPodiumScene)
         {
             //Debug.Log("sec pot input detected");
             UsePotion2();
@@ -128,7 +129,7 @@ public abstract class GenericCharacter : MonoBehaviour
 
     public void SpecialPotInput(InputAction.CallbackContext context)
     {
-        if (timeBtwAttack <= 0 && canMove)
+        if (timeBtwAttack <= 0 && canMove && !isPodiumScene)
         {
             //Debug.Log("special pot input detected");
             UsePotion3();
@@ -192,8 +193,6 @@ public abstract class GenericCharacter : MonoBehaviour
 
     public void UsePotion3()
     {
-        // remember to check if there's any more potions left.
-        // if playerScript.UseSpecialPotionIfCanUse() -> use
         if (playerScript.UseSpecialPotionIfCanUse())
         {
             Debug.Log("Potion 3!");
@@ -216,7 +215,17 @@ public abstract class GenericCharacter : MonoBehaviour
 
     }
 
-    public abstract void OnDeath();
+    public void OnDeath()
+    {
+        // if on podium scene, characters will not have death animations
+        if (!isPodiumScene)
+        {
+            animator.SetBool("IsJumping", false);
+            animator.SetTrigger("Death");
+            float deathAnimLength = animator.GetCurrentAnimatorStateInfo(0).length;
+            StartCoroutine(SetSpawnPosition(deathAnimLength));
+        }
+    }
 
     // implement methods for all the different potion 3s here
     public void SwiftnessElixir()
@@ -296,6 +305,7 @@ public abstract class GenericCharacter : MonoBehaviour
         canMove = !isCharacterDreaming;
     }
 
+    // Spawning after death
     protected IEnumerator SetSpawnPosition(float deathAnimLength)
     {
         audioSrc.PlayOneShot(deathSFX);

--- a/Term8_GameDesign/Assets/Scripts/Characters/GenericCharacter.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/GenericCharacter.cs
@@ -186,6 +186,12 @@ public abstract class GenericCharacter : MonoBehaviour
         wasHurted = false;
     }
 
+    public void InstantUnhurtPlayer()
+    {
+        animator.SetLayerWeight(1, 0);
+        wasHurted = false;
+    }
+
     // abstract methods must be implemented by child classes
     public abstract void UseCharacterPotion();
 

--- a/Term8_GameDesign/Assets/Scripts/Characters/GenericPlayer.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/GenericPlayer.cs
@@ -85,6 +85,8 @@ public class GenericPlayer : MonoBehaviour
             {
                 Debug.Log("I am now in podium, my player number is " + playerNum);
                 genericCharacter.isPodiumScene = true;
+                // unhurt player if it was hurted
+                genericCharacter.InstantUnhurtPlayer();
             }
             else
             {

--- a/Term8_GameDesign/Assets/Scripts/Characters/GenericPlayer.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/GenericPlayer.cs
@@ -19,6 +19,10 @@ public class GenericPlayer : MonoBehaviour
     [SerializeField]
     private ScreensTransitionManager screensTransitionManager;
 
+    // pickup variables
+    protected int weetsPickUpAmt = 20;
+    protected int secPotPickUpQty = 2;
+
     void Awake()
     {
         genericCharacter = GetComponentInChildren<GenericCharacter>();
@@ -35,6 +39,8 @@ public class GenericPlayer : MonoBehaviour
         gameManager.OnDeathEvent += GenericPlayerDeath;         // subscribe so that GenericPlayer knows when to die
         gameManager.OnMuddledEvent += PlayerMuddled;
         gameManager.OnDreamingEvent += PlayerDreaming;
+        gameManager.OnPodiumSceneEvent += PlayerOnPodium;
+
     }
 
     // Event Handlers
@@ -68,6 +74,23 @@ public class GenericPlayer : MonoBehaviour
             genericCharacter.SetDreaming(true);
             genericCharacter.allStatusEffects[1].gameObject.SetActive(true);
             StartCoroutine(RevertDreaming());
+        }
+    }
+
+    private void PlayerOnPodium(bool enteringPodium)
+    {
+        if (genericCharacter)
+        {
+            if (enteringPodium)
+            {
+                Debug.Log("I am now in podium, my player number is " + playerNum);
+                genericCharacter.isPodiumScene = true;
+            }
+            else
+            {
+                Debug.Log("I am now not in podium, my player number is " + playerNum);
+                genericCharacter.isPodiumScene = false;
+            }
         }
     }
 
@@ -111,7 +134,6 @@ public class GenericPlayer : MonoBehaviour
 
     public SpecialPotionType GetSpecialPotionType()
     {
-        // TODO: refactor this? feels inefficient to fetch special potion from PlayerStats each time
         return gameManager.GetSpecialPotionType(playerNum);
     }
 
@@ -137,16 +159,12 @@ public class GenericPlayer : MonoBehaviour
 
     public void AddWeets()
     {
-        // TODO: change amount of weets
-        int amt = 20;
-        gameManager.AddWeets(playerNum, amt);
+        gameManager.AddWeets(playerNum, weetsPickUpAmt);
     }
 
     public void AddSecPotionQty()
     {
-        // TODO: change amount of secQty
-        int amt = 2;
-        gameManager.AddSecPotionQty(playerNum, amt);
+        gameManager.AddSecPotionQty(playerNum, secPotPickUpQty);
     }
 
     public void AttachCharacter(CharacterType charType)

--- a/Term8_GameDesign/Assets/Scripts/Characters/Lumira.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/Lumira.cs
@@ -59,13 +59,4 @@ public class Lumira : GenericCharacter
             Debug.Log("Potion 2!!");
         }
     }
-
-    public override void OnDeath()
-    {
-        // trigger death animation
-        animator.SetBool("IsJumping", false);
-        animator.SetTrigger("Death");
-        float deathAnimLength = animator.GetCurrentAnimatorStateInfo(0).length;
-        StartCoroutine(SetSpawnPosition(deathAnimLength));
-    }
 }

--- a/Term8_GameDesign/Assets/Scripts/Characters/Murasaki.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/Murasaki.cs
@@ -59,13 +59,4 @@ public class Murasaki : GenericCharacter
             Debug.Log("Potion 2!!");
         }
     }
-
-    public override void OnDeath()
-    {
-        // trigger death animation
-        animator.SetBool("IsJumping", false);
-        animator.SetTrigger("Death");
-        float deathAnimLength = animator.GetCurrentAnimatorStateInfo(0).length;
-        StartCoroutine(SetSpawnPosition(deathAnimLength));
-    }
 }

--- a/Term8_GameDesign/Assets/Scripts/Characters/TheTraveller.cs
+++ b/Term8_GameDesign/Assets/Scripts/Characters/TheTraveller.cs
@@ -63,13 +63,4 @@ public class TheTraveller : GenericCharacter
         }
         
     }
-
-    public override void OnDeath()
-    {
-        // trigger death animation
-        animator.SetBool("IsJumping", false);
-        animator.SetTrigger("Death");
-        float deathAnimLength = animator.GetCurrentAnimatorStateInfo(0).length;
-        StartCoroutine(SetSpawnPosition(deathAnimLength));
-    }
 }

--- a/Term8_GameDesign/Assets/Scripts/GameManager.cs
+++ b/Term8_GameDesign/Assets/Scripts/GameManager.cs
@@ -32,6 +32,10 @@ public class GameManager : MonoBehaviour
     public CameraShake mainCamShake;
     public bool enableCamShakeOnDeath = true;
 
+    // For Podium Scene
+    public delegate void PodiumDelegate(bool enteringPodium);
+    public event PodiumDelegate OnPodiumSceneEvent;
+
     private ScreensTransitionManager screensTransitionManager;
 
     void Start()
@@ -68,8 +72,6 @@ public class GameManager : MonoBehaviour
     {
         PlayerStats receivingPlayer = playersHashTable[receivingPlayerNum];
         PlayerStats attackingPlayer = playersHashTable[attackingPlayerNum];
-        Debug.Log(receivingPlayer);
-        Debug.Log(attackingPlayer);
         if (receivingPlayer != attackingPlayer)
         {
             receivingPlayer.PlayerHealth -= attackingPlayer.DamageDealtToOthers;
@@ -181,6 +183,13 @@ public class GameManager : MonoBehaviour
         playersGameOverlayUI[playerNum].UpdateSecondaryQty(requiredPlayer.SecondaryPotionQty);
     }
 
+    // Podium ======================================
+    public void EnterPodium()
+    {
+        // let all players know that they are in podium
+        OnPodiumSceneEvent?.Invoke(true);
+    }
+
     // When game ends, reset player scriptable object ======================================
     void OnDestroy()
     {
@@ -195,6 +204,8 @@ public class GameManager : MonoBehaviour
 
     void ResetAllPlayers()
     {
+        // invoke not in podium anymore (if it was even in podium)
+        OnPodiumSceneEvent?.Invoke(false);
         ResetPlayer(player0);
         ResetPlayer(player1);
         ResetPlayer(player2);

--- a/Term8_GameDesign/Assets/Scripts/GameManager.cs
+++ b/Term8_GameDesign/Assets/Scripts/GameManager.cs
@@ -188,6 +188,8 @@ public class GameManager : MonoBehaviour
     {
         // let all players know that they are in podium
         OnPodiumSceneEvent?.Invoke(true);
+        // disable camera shake
+        enableCamShakeOnDeath = false;
     }
 
     // When game ends, reset player scriptable object ======================================
@@ -206,6 +208,8 @@ public class GameManager : MonoBehaviour
     {
         // invoke not in podium anymore (if it was even in podium)
         OnPodiumSceneEvent?.Invoke(false);
+        // enable camera shake
+        enableCamShakeOnDeath = true;
         ResetPlayer(player0);
         ResetPlayer(player1);
         ResetPlayer(player2);

--- a/Term8_GameDesign/Assets/Scripts/Screens/PodiumGenerator.cs
+++ b/Term8_GameDesign/Assets/Scripts/Screens/PodiumGenerator.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 // crate sprite : http://clipart-library.com/clipart/22069.htm
@@ -21,6 +23,7 @@ public class PodiumGenerator : MonoBehaviour
     [SerializeField]
     private AfterMatchManager afterMatchManager;
     private ScreensTransitionManager screensTransitionManager;
+    private GameManager gameManager;
     private bool gotPositions;
     AudioSource thump;
 
@@ -29,6 +32,8 @@ public class PodiumGenerator : MonoBehaviour
     void OnEnable()
     {
         screensTransitionManager = FindObjectOfType<ScreensTransitionManager>();
+        gameManager = FindObjectOfType<GameManager>();
+        gameManager.EnterPodium();
 
         numberOfPlayers = screensTransitionManager.requiredPlayersToStart;
         positions = new int[numberOfPlayers];
@@ -79,9 +84,9 @@ public class PodiumGenerator : MonoBehaviour
 
     private IEnumerator SpawnCrate()
     {
-        for (int y = 0; y < YValues.Length; y++)
+        for (int y = 0; y < numberOfPlayers ; y++)
         {
-            for (int x = 0; x < XValues.Length; x++)
+            for (int x = 0; x < numberOfPlayers; x++)
             {
                 if (y >= (YValues.Length-positions[x]+1))
                 {

--- a/Term8_GameDesign/Assets/Scripts/Screens/ScreensTransitionManager.cs
+++ b/Term8_GameDesign/Assets/Scripts/Screens/ScreensTransitionManager.cs
@@ -144,10 +144,10 @@ public class ScreensTransitionManager : MonoBehaviour
         controlsManager.SwitchAllControllersToUIMode();
     }
 
-    private IEnumerator DestroyPickups()
+    private IEnumerator DestroyPickups(float delay)
     {
         // after screen has transited to match conclusion
-        yield return new WaitForSeconds(2.1f);
+        yield return new WaitForSeconds(delay);
         spawnPickupsScript.DestroyPickups();
     }
 
@@ -244,13 +244,14 @@ public class ScreensTransitionManager : MonoBehaviour
             if (matchNum <= 2)
             {
                 StartCoroutine(SwitchControllers());
-                StartCoroutine(DestroyPickups());
+                StartCoroutine(DestroyPickups(2.1f));
             }
             else
             {
                 screenNum = 5;
                 readyPlayersNum = 0;
                 StartCoroutine(ToFinal());
+                StartCoroutine(DestroyPickups(1f));
             }
         }
     }


### PR DESCRIPTION
Upon entering podium scene,
- Disable player death animation
- Disable secondary & special potions usage
- Disable camera shake upon "death"
- Destroy any pickups still on the scene